### PR TITLE
Create abstract+example implementations of LedgerEventHandler and wire into SimpleLedger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 .settings/*
 *~
 /nbproject/
+/.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>19.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
       <version>2.7.0</version>
@@ -63,6 +68,11 @@
       <artifactId>junit</artifactId>
       <version>4.12</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/src/main/java/org/interledger/ilp/ledger/events/AbstractEventBusLedgerEventHandler.java
+++ b/src/main/java/org/interledger/ilp/ledger/events/AbstractEventBusLedgerEventHandler.java
@@ -1,0 +1,90 @@
+package org.interledger.ilp.ledger.events;
+
+import com.google.common.base.Preconditions;
+import com.google.common.eventbus.DeadEvent;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import org.interledger.ilp.core.events.LedgerConnectedEvent;
+import org.interledger.ilp.core.events.LedgerDirectTransferEvent;
+import org.interledger.ilp.core.events.LedgerDisonnectedEvent;
+import org.interledger.ilp.core.events.LedgerEvent;
+import org.interledger.ilp.core.events.LedgerEventHandler;
+import org.interledger.ilp.core.events.LedgerTransferExecutedEvent;
+import org.interledger.ilp.core.events.LedgerTransferPreparedEvent;
+import org.interledger.ilp.core.events.LedgerTransferRejectedEvent;
+
+import java.util.logging.Logger;
+
+/**
+ * An extension of {@link AbstractLedgerEventHandler} that implements {@link LedgerEventHandler} and uses Guava's
+ * {@link EventBus} to route all ILP ledger events.
+ */
+public abstract class AbstractEventBusLedgerEventHandler extends AbstractLedgerEventHandler implements LedgerEventHandler<LedgerEvent> {
+
+    protected Logger logger = Logger.getLogger(this.getClass().getName());
+
+    private final EventBus eventBus;
+
+    /**
+     * No-args Constructor.  Provides a default implementation of all dependencies.
+     */
+    public AbstractEventBusLedgerEventHandler() {
+        this(new EventBus());
+    }
+
+    /**
+     * Required-args Constructor.
+     *
+     * @param eventBus An instance of {@link EventBus} that can be custom-configured by the creator of this class.
+     */
+    public AbstractEventBusLedgerEventHandler(final EventBus eventBus) {
+        this.eventBus = eventBus;
+        this.eventBus.register(this);
+    }
+
+    /**
+     * Handles a {@link LedgerEvent} in a type-safe fashion and accounts for unhandled events.
+     *
+     * @param ledgerEvent An instance of {@link LedgerEvent}.
+     */
+    @Override
+    protected final void handleInternal(final LedgerEvent ledgerEvent) {
+        Preconditions.checkNotNull(ledgerEvent);
+        eventBus.post(ledgerEvent);
+    }
+
+    // This override is necessary to wire-up to the EventBus.
+    @Override
+    @Subscribe
+    protected abstract boolean handleEvent(final LedgerConnectedEvent ledgerConnectedEvent);
+
+    // This override is necessary to wire-up to the EventBus.
+    @Override
+    @Subscribe
+    protected abstract boolean handleEvent(final LedgerDisonnectedEvent ledgerDisonnectedEvent);
+
+    // This override is necessary to wire-up to the EventBus.
+    @Override
+    @Subscribe
+    protected abstract boolean handleEvent(final LedgerTransferPreparedEvent ledgerTransferPreparedEvent);
+
+    // This override is necessary to wire-up to the EventBus.
+    @Override
+    @Subscribe
+    protected abstract boolean handleEvent(final LedgerTransferExecutedEvent ledgerTransferExecutedEvent);
+
+    // This override is necessary to wire-up to the EventBus.
+    @Override
+    @Subscribe
+    protected abstract boolean handleEvent(final LedgerDirectTransferEvent ledgerDirectTransferEvent);
+
+    // This override is necessary to wire-up to the EventBus.
+    @Override
+    @Subscribe
+    protected abstract boolean handleEvent(final LedgerTransferRejectedEvent ledgerTransferRejectedEvent);
+
+    @Subscribe
+    protected boolean deadEvent(final DeadEvent deadEvent) {
+        throw new RuntimeException("Unhandled Event: " + deadEvent);
+    }
+}

--- a/src/main/java/org/interledger/ilp/ledger/events/AbstractLedgerEventHandler.java
+++ b/src/main/java/org/interledger/ilp/ledger/events/AbstractLedgerEventHandler.java
@@ -1,0 +1,108 @@
+package org.interledger.ilp.ledger.events;
+
+import com.google.common.base.Preconditions;
+import org.interledger.ilp.core.events.LedgerConnectedEvent;
+import org.interledger.ilp.core.events.LedgerDirectTransferEvent;
+import org.interledger.ilp.core.events.LedgerDisonnectedEvent;
+import org.interledger.ilp.core.events.LedgerEvent;
+import org.interledger.ilp.core.events.LedgerEventHandler;
+import org.interledger.ilp.core.events.LedgerTransferExecutedEvent;
+import org.interledger.ilp.core.events.LedgerTransferPreparedEvent;
+import org.interledger.ilp.core.events.LedgerTransferRejectedEvent;
+
+/**
+ * An abstract implementation of {@link LedgerEventHandler} that handles all variants of {@link LedgerEvent} in a
+ * type-safe manner, and provides a mechanism to detect unhandled event-types at runtime.
+ */
+public abstract class AbstractLedgerEventHandler implements LedgerEventHandler<LedgerEvent> {
+
+    @Override
+    public final void onLedgerEvent(final LedgerEvent ledgerEvent) {
+        this.handleInternal(ledgerEvent);
+    }
+
+    /**
+     * Handles a {@link LedgerEvent} in a type-safe fashion and accounts for unhandled events.
+     *
+     * @param ledgerEvent An instance of {@link LedgerEvent}.
+     */
+    protected void handleInternal(final LedgerEvent ledgerEvent) {
+        Preconditions.checkNotNull(ledgerEvent);
+
+        // If this were a more recent version of Java, this could be a Switch statement...
+        if (ledgerEvent.getClass().equals(LedgerConnectedEvent.class)) {
+            this.handleEvent((LedgerConnectedEvent) ledgerEvent);
+        } else if (ledgerEvent.getClass().equals(LedgerDisonnectedEvent.class)) {
+            this.handleEvent((LedgerDisonnectedEvent) ledgerEvent);
+        } else if (ledgerEvent.getClass().equals(LedgerTransferPreparedEvent.class)) {
+            this.handleEvent((LedgerTransferPreparedEvent) ledgerEvent);
+        } else if (ledgerEvent.getClass().equals(LedgerTransferExecutedEvent.class)) {
+            this.handleEvent((LedgerTransferExecutedEvent) ledgerEvent);
+        } else if (ledgerEvent.getClass().equals(LedgerDirectTransferEvent.class)) {
+            this.handleEvent((LedgerDirectTransferEvent) ledgerEvent);
+        } else if (ledgerEvent.getClass().equals(LedgerTransferRejectedEvent.class)) {
+            this.handleEvent((LedgerTransferRejectedEvent) ledgerEvent);
+        } else {
+            this.handleUnhandledEvent(ledgerEvent);
+        }
+    }
+
+    /**
+     * Handle an instance of {@link LedgerConnectedEvent}.
+     *
+     * @param ledgerConnectedEvent An instance of {@link LedgerConnectedEvent}.
+     * @return {@code true} if the event was handled; {@code false} otherwise.
+     */
+    protected abstract boolean handleEvent(final LedgerConnectedEvent ledgerConnectedEvent);
+
+    /**
+     * Handle an instance of {@link LedgerDisonnectedEvent}.
+     *
+     * @param ledgerDisonnectedEvent An instance of {@link LedgerDisonnectedEvent}.
+     * @return {@code true} if the event was handled; {@code false} otherwise.
+     */
+    protected abstract boolean handleEvent(final LedgerDisonnectedEvent ledgerDisonnectedEvent);
+
+    /**
+     * Handle an instance of {@link LedgerTransferPreparedEvent}.
+     *
+     * @param ledgerTransferPreparedEvent An instance of {@link LedgerTransferPreparedEvent}.
+     * @return {@code true} if the event was handled; {@code false} otherwise.
+     */
+    protected abstract boolean handleEvent(final LedgerTransferPreparedEvent ledgerTransferPreparedEvent);
+
+    /**
+     * Handle an instance of {@link LedgerTransferExecutedEvent}.
+     *
+     * @param ledgerTransferExecutedEvent An instance of {@link LedgerTransferExecutedEvent}.
+     * @return {@code true} if the event was handled; {@code false} otherwise.
+     */
+    protected abstract boolean handleEvent(final LedgerTransferExecutedEvent ledgerTransferExecutedEvent);
+
+    /**
+     * Handle an instance of {@link LedgerDirectTransferEvent}.
+     *
+     * @param ledgerDirectTransferEvent An instance of {@link LedgerDirectTransferEvent}.
+     * @return {@code true} if the event was handled; {@code false} otherwise.
+     */
+    protected abstract boolean handleEvent(final LedgerDirectTransferEvent ledgerDirectTransferEvent);
+
+    /**
+     * Handle an instance of {@link LedgerTransferRejectedEvent}.
+     *
+     * @param ledgerTransferRejectedEvent An instance of {@link LedgerTransferRejectedEvent}.
+     * @return {@code true} if the event was handled; {@code false} otherwise.
+     */
+    protected abstract boolean handleEvent(final LedgerTransferRejectedEvent ledgerTransferRejectedEvent);
+
+    /**
+     * Throws a {@link RuntimeException} if an un-handled event is encountered.  Protected so that sub-classes can
+     * override this behavior, if desired.
+     *
+     * @param ledgerEvent An instance of {@link LedgerEvent} that is unhandled by this
+     * @return {@code true} if the event was handled; {@code false} otherwise.
+     */
+    protected boolean handleUnhandledEvent(final LedgerEvent ledgerEvent) {
+        throw new RuntimeException("Unhandled Event: " + ledgerEvent);
+    }
+}

--- a/src/main/java/org/interledger/ilp/ledger/events/SimpleEventBusLedgerEventHandler.java
+++ b/src/main/java/org/interledger/ilp/ledger/events/SimpleEventBusLedgerEventHandler.java
@@ -1,0 +1,64 @@
+package org.interledger.ilp.ledger.events;
+
+import com.google.common.eventbus.EventBus;
+import org.interledger.ilp.core.events.LedgerConnectedEvent;
+import org.interledger.ilp.core.events.LedgerDirectTransferEvent;
+import org.interledger.ilp.core.events.LedgerDisonnectedEvent;
+import org.interledger.ilp.core.events.LedgerEvent;
+import org.interledger.ilp.core.events.LedgerEventHandler;
+import org.interledger.ilp.core.events.LedgerTransferExecutedEvent;
+import org.interledger.ilp.core.events.LedgerTransferPreparedEvent;
+import org.interledger.ilp.core.events.LedgerTransferRejectedEvent;
+
+/**
+ * An extension  of {@link AbstractEventBusLedgerEventHandler} that implements {@link LedgerEventHandler} by using
+ * Guava's {@link EventBus} to handleInternal all subscription and listener logic related to events from an ILP leger.
+ * This implementation is intended to be used by an in-memory ledger.
+ */
+public class SimpleEventBusLedgerEventHandler extends AbstractEventBusLedgerEventHandler implements LedgerEventHandler<LedgerEvent> {
+
+    /**
+     * Required-args Constructor.
+     *
+     * @param eventBus An instance of {@link EventBus} that can be custom-configured by the creator of this class.
+     */
+    public SimpleEventBusLedgerEventHandler(final EventBus eventBus) {
+        super(eventBus);
+    }
+
+    @Override
+    protected boolean handleEvent(final LedgerConnectedEvent ledgerConnectedEvent) {
+        logger.info("Received Event: " + ledgerConnectedEvent);
+        return true;
+    }
+
+    @Override
+    protected boolean handleEvent(final LedgerDisonnectedEvent ledgerDisonnectedEvent) {
+        logger.info("Received Event: " + ledgerDisonnectedEvent);
+        return true;
+    }
+
+    @Override
+    protected boolean handleEvent(final LedgerTransferPreparedEvent ledgerTransferPreparedEvent) {
+        logger.info("Received Event: " + ledgerTransferPreparedEvent);
+        return true;
+    }
+
+    @Override
+    protected boolean handleEvent(final LedgerTransferExecutedEvent ledgerTransferExecutedEvent) {
+        logger.info("Received Event: " + ledgerTransferExecutedEvent);
+        return true;
+    }
+
+    @Override
+    protected boolean handleEvent(final LedgerDirectTransferEvent ledgerDirectTransferEvent) {
+        logger.info("Received Event: " + ledgerDirectTransferEvent);
+        return true;
+    }
+
+    @Override
+    protected boolean handleEvent(final LedgerTransferRejectedEvent ledgerTransferRejectedEvent) {
+        logger.info("Received Event: " + ledgerTransferRejectedEvent);
+        return true;
+    }
+}

--- a/src/main/java/org/interledger/ilp/ledger/impl/SimpleLedger.java
+++ b/src/main/java/org/interledger/ilp/ledger/impl/SimpleLedger.java
@@ -77,13 +77,6 @@ public class SimpleLedger implements Ledger, LedgerAccountManagerAware {
                 this, transfer.getHeader(), transfer.getFromAccount(), transfer.getToAccount(), transfer.getAmount()
         );
         this.notifyEventHandlers(ledgerTransferExecutedEvent);
-        final LedgerEvent ledgerEvent = new LedgerEvent(this) {
-            @Override
-            public Ledger getLedger() {
-                return super.getLedger();
-            }
-        };
-        this.notifyEventHandlers(ledgerEvent);
     }
 
     public void rejectTransfer(LedgerTransfer transfer, LedgerTransferRejectedReason reason) {

--- a/src/test/java/org/interledger/ilp/ledger/events/AbstractEventBusLedgerEventHandlerTest.java
+++ b/src/test/java/org/interledger/ilp/ledger/events/AbstractEventBusLedgerEventHandlerTest.java
@@ -1,0 +1,115 @@
+package org.interledger.ilp.ledger.events;
+
+import com.google.common.eventbus.DeadEvent;
+import org.interledger.ilp.core.events.LedgerConnectedEvent;
+import org.interledger.ilp.core.events.LedgerDirectTransferEvent;
+import org.interledger.ilp.core.events.LedgerDisonnectedEvent;
+import org.interledger.ilp.core.events.LedgerEvent;
+import org.interledger.ilp.core.events.LedgerTransferExecutedEvent;
+import org.interledger.ilp.core.events.LedgerTransferPreparedEvent;
+import org.interledger.ilp.core.events.LedgerTransferRejectedEvent;
+import org.interledger.ilp.ledger.events.AbstractEventBusLedgerEventHandler;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit test for {@link AbstractEventBusLedgerEventHandler}.  Merely tests that the abstract super-class is wired
+ * properly to the Guava Event Bus.
+ */
+public class AbstractEventBusLedgerEventHandlerTest {
+
+    private boolean ledgerConnectedEventHandled = false;
+    private boolean ledgerDisonnectedEventHandled = false;
+    private boolean ledgerTransferPreparedEventHandled = false;
+    private boolean ledgerTransferExecutedEventHandled = false;
+    private boolean ledgerTransferRejectedEventHandled = false;
+    private boolean ledgerDirectTransferEventHandled = false;
+    private boolean deadEventHandled = false;
+
+    private AbstractEventBusLedgerEventHandler handler = new AbstractEventBusLedgerEventHandler() {
+
+        @Override
+        protected boolean handleEvent(LedgerConnectedEvent ledgerConnectedEvent) {
+            ledgerConnectedEventHandled = true;
+            return true;
+        }
+
+        @Override
+        protected boolean handleEvent(LedgerDisonnectedEvent ledgerDisonnectedEvent) {
+            ledgerDisonnectedEventHandled = true;
+            return true;
+        }
+
+        @Override
+        protected boolean handleEvent(
+                LedgerTransferPreparedEvent ledgerTransferPreparedEvent
+        ) {
+            ledgerTransferPreparedEventHandled = true;
+            return true;
+        }
+
+        @Override
+        protected boolean handleEvent(
+                LedgerTransferExecutedEvent ledgerTransferExecutedEvent
+        ) {
+            ledgerTransferExecutedEventHandled = true;
+            return true;
+        }
+
+        @Override
+        protected boolean handleEvent(LedgerDirectTransferEvent ledgerDirectTransferEvent) {
+            ledgerDirectTransferEventHandled = true;
+            return true;
+        }
+
+        @Override
+        protected boolean handleEvent(
+                LedgerTransferRejectedEvent ledgerTransferRejectedEvent
+        ) {
+            ledgerTransferRejectedEventHandled = true;
+            return true;
+        }
+
+        @Override
+        protected boolean deadEvent(final DeadEvent deadEvent) {
+            deadEventHandled = true;
+            return true;
+        }
+    };
+
+    /**
+     * Assert that each event-bus handler method is called in response to a {@link LedgerEvent} of the proper type.  If
+     * anything is mis-wired, then this test will fail.
+     */
+    @Test
+    public void onLedgerEvents() {
+        handler.onLedgerEvent(mock(LedgerConnectedEvent.class));
+        handler.onLedgerEvent(mock(LedgerDisonnectedEvent.class));
+        handler.onLedgerEvent(mock(LedgerTransferPreparedEvent.class));
+        handler.onLedgerEvent(mock(LedgerTransferExecutedEvent.class));
+        handler.onLedgerEvent(mock(LedgerTransferRejectedEvent.class));
+        handler.onLedgerEvent(mock(LedgerDirectTransferEvent.class));
+
+        assertThat(ledgerConnectedEventHandled, is(true));
+        assertThat(ledgerDisonnectedEventHandled, is(true));
+        assertThat(ledgerTransferPreparedEventHandled, is(true));
+        assertThat(ledgerTransferExecutedEventHandled, is(true));
+        assertThat(ledgerTransferRejectedEventHandled, is(true));
+        assertThat(ledgerDirectTransferEventHandled, is(true));
+        assertThat(deadEventHandled, is(false));
+    }
+
+    /**
+     * Test that the dead-event handler is wired properly.
+     */
+    @Test
+    public void testDeadEvent() {
+        // Raw LedgerEvent is currently un-handled.
+        handler.onLedgerEvent(mock(LedgerEvent.class));
+        assertThat(deadEventHandled, is(true));
+    }
+
+}

--- a/src/test/java/org/interledger/ilp/ledger/events/AbstractLedgerEventHandlerTest.java
+++ b/src/test/java/org/interledger/ilp/ledger/events/AbstractLedgerEventHandlerTest.java
@@ -1,0 +1,125 @@
+package org.interledger.ilp.ledger.events;
+
+import org.interledger.ilp.core.InterledgerPacketHeader;
+import org.interledger.ilp.core.Ledger;
+import org.interledger.ilp.core.LedgerTransferRejectedReason;
+import org.interledger.ilp.core.events.LedgerConnectedEvent;
+import org.interledger.ilp.core.events.LedgerDirectTransferEvent;
+import org.interledger.ilp.core.events.LedgerDisonnectedEvent;
+import org.interledger.ilp.core.events.LedgerEvent;
+import org.interledger.ilp.core.events.LedgerTransferExecutedEvent;
+import org.interledger.ilp.core.events.LedgerTransferPreparedEvent;
+import org.interledger.ilp.core.events.LedgerTransferRejectedEvent;
+import org.interledger.ilp.ledger.events.AbstractEventBusLedgerEventHandler;
+import org.interledger.ilp.ledger.events.AbstractLedgerEventHandler;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit test for {@link AbstractEventBusLedgerEventHandler}.  Merely tests that the abstract super-class is wired
+ * properly to the Guava Event Bus.
+ */
+public class AbstractLedgerEventHandlerTest {
+
+    private boolean ledgerConnectedEventHandled = false;
+    private boolean ledgerDisonnectedEventHandled = false;
+    private boolean ledgerTransferPreparedEventHandled = false;
+    private boolean ledgerTransferExecutedEventHandled = false;
+    private boolean ledgerTransferRejectedEventHandled = false;
+    private boolean ledgerDirectTransferEventHandled = false;
+
+    /**
+     * An instance of {@link AbstractLedgerEventHandler} for testing purposes to check if each handler method was called
+     * properly.
+     */
+    private AbstractLedgerEventHandler handler = new AbstractLedgerEventHandler() {
+        @Override
+        protected boolean handleEvent(LedgerConnectedEvent ledgerConnectedEvent) {
+            ledgerConnectedEventHandled = true;
+            return true;
+        }
+
+        @Override
+        protected boolean handleEvent(LedgerDisonnectedEvent ledgerDisonnectedEvent) {
+            ledgerDisonnectedEventHandled = true;
+            return true;
+        }
+
+        @Override
+        protected boolean handleEvent(
+                LedgerTransferPreparedEvent ledgerTransferPreparedEvent
+        ) {
+            ledgerTransferPreparedEventHandled = true;
+            return true;
+        }
+
+        @Override
+        protected boolean handleEvent(
+                LedgerTransferExecutedEvent ledgerTransferExecutedEvent
+        ) {
+            ledgerTransferExecutedEventHandled = true;
+            return true;
+        }
+
+        @Override
+        protected boolean handleEvent(LedgerDirectTransferEvent ledgerDirectTransferEvent) {
+            ledgerDirectTransferEventHandled = true;
+            return true;
+        }
+
+        @Override
+        protected boolean handleEvent(
+                LedgerTransferRejectedEvent ledgerTransferRejectedEvent
+        ) {
+            ledgerTransferRejectedEventHandled = true;
+            return true;
+        }
+    };
+
+    /**
+     * Assert that each handler method is called in response to a {@link LedgerEvent} of the proper type.  If
+     * anything is mis-wired, then this test will fail.
+     */
+    @Test
+    public void onLedgerEvents() {
+        final InterledgerPacketHeader interledgerPacketHeaderMock = mock(InterledgerPacketHeader.class);
+        when(interledgerPacketHeaderMock.isOptimisticModeHeader()).thenReturn(true);
+
+        handler.onLedgerEvent(new LedgerConnectedEvent(mock(Ledger.class)));
+        handler.onLedgerEvent(new LedgerDisonnectedEvent(mock(Ledger.class)));
+        handler.onLedgerEvent(
+                new LedgerTransferPreparedEvent(mock(Ledger.class), interledgerPacketHeaderMock, "", "", ""));
+        handler.onLedgerEvent(
+                new LedgerTransferExecutedEvent(mock(Ledger.class), interledgerPacketHeaderMock, "", "", ""));
+        handler.onLedgerEvent(
+                new LedgerTransferRejectedEvent(mock(Ledger.class), interledgerPacketHeaderMock, "", "", "",
+                                                LedgerTransferRejectedReason.REJECTED_BY_RECEIVER
+                ));
+        handler.onLedgerEvent(
+                new LedgerDirectTransferEvent(mock(Ledger.class), interledgerPacketHeaderMock, "", "", ""));
+
+        assertThat(ledgerConnectedEventHandled, is(true));
+        assertThat(ledgerDisonnectedEventHandled, is(true));
+        assertThat(ledgerTransferPreparedEventHandled, is(true));
+        assertThat(ledgerTransferExecutedEventHandled, is(true));
+        assertThat(ledgerTransferRejectedEventHandled, is(true));
+        assertThat(ledgerDirectTransferEventHandled, is(true));
+    }
+
+    /**
+     * Test that the dead-event handler is wired properly.
+     */
+    @Test(expected = RuntimeException.class)
+    public void testDeadEvent() {
+        // Raw LedgerEvent is currently un-handled.
+        try {
+            handler.onLedgerEvent(mock(LedgerEvent.class));
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage().startsWith("Unhandled Event: "), is(true));
+            throw e;
+        }
+    }
+}

--- a/src/test/java/org/interledger/ilp/ledger/events/SimpleLedgerEventHandlerTest.java
+++ b/src/test/java/org/interledger/ilp/ledger/events/SimpleLedgerEventHandlerTest.java
@@ -1,0 +1,62 @@
+package org.interledger.ilp.ledger.events;
+
+import com.google.common.eventbus.EventBus;
+import org.interledger.ilp.core.LedgerTransfer;
+import org.interledger.ilp.ledger.Currencies;
+import org.interledger.ilp.ledger.account.LedgerAccount;
+import org.interledger.ilp.ledger.events.SimpleEventBusLedgerEventHandler;
+import org.interledger.ilp.ledger.impl.LedgerTransferBuilder;
+import org.interledger.ilp.ledger.impl.SimpleLedger;
+import org.interledger.ilp.ledger.impl.SimpleLedgerAccount;
+import org.javamoney.moneta.Money;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.money.MonetaryAmount;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Simple ledger tests
+ *
+ * @author mrmx
+ */
+public class SimpleLedgerEventHandlerTest {
+
+    private EventBus eventBus;
+    Currencies CURRENCY = Currencies.EURO;
+    SimpleLedger simpleLedger;
+
+    @Before
+    public void setUp() {
+        this.eventBus = new EventBus();
+        simpleLedger = new SimpleLedger(CURRENCY, "test");
+    }
+
+    /**
+     * Test of registerEventHandler method, of class SimpleLedger.
+     */
+    @Test
+    public void testRegisterEventHandler() {
+        System.out.println("registerEventHandler");
+
+        final SimpleEventBusLedgerEventHandler handler = new SimpleEventBusLedgerEventHandler(this.eventBus);
+        simpleLedger.registerEventHandler(handler);
+
+        System.out.println("send");
+        LedgerAccount alice = new SimpleLedgerAccount("alice", CURRENCY.code()).setBalance(100);
+        LedgerAccount bob = new SimpleLedgerAccount("bob", CURRENCY.code()).setBalance(100);
+        simpleLedger.getLedgerAccountManager().addAccount(alice);
+        simpleLedger.getLedgerAccountManager().addAccount(bob);
+        LedgerTransfer transfer = LedgerTransferBuilder.instance()
+                .from(alice)
+                .destination("bob@test")
+                .amount(Money.of(10, CURRENCY.code()))
+                .build();
+        simpleLedger.send(transfer);
+        alice = simpleLedger.getLedgerAccountManager().getAccountByName("alice");
+        assertThat(alice.getBalance(), is((MonetaryAmount) Money.of(90, "EUR")));
+    }
+
+}


### PR DESCRIPTION
This PR provides some abstract LedgeEventHandler implementations that provide a foundation for handling events in this simple ledger.

* Create abstract classes to provide wiring for LedgerEventHandler implementations
* Provide an example implementation of a LedgerEventHandler that uses Guava in-memory eventBus.
* Updates `SimpleLedger.send` to notify the LedgerEventHandler that a transfer was executed.